### PR TITLE
Ember cli install

### DIFF
--- a/ahalogy-automation.gemspec
+++ b/ahalogy-automation.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'ahalogy-automation'
-  gem.version     = '0.0.7'
+  gem.version     = '0.0.8'
   gem.licenses    = ['MIT']
   gem.date        = '2015-06-26'
   gem.summary     = 'Scripts to handle IT automation.'

--- a/bin/a5y-configure
+++ b/bin/a5y-configure
@@ -230,6 +230,7 @@ begin
     add_line_to_file '~/.zshrc', 'export NVM_DIR=~/.nvm'
     add_line_to_file '~/.zshrc', 'source $(brew --prefix nvm)/nvm.sh'
     # install ember-cli
+    run_cmd 'npm install -g bower', 'Installing bower...'
     run_cmd 'npm install -g ember-cli', 'Installing ember-cli...'
     # Setup pow
     unless File.directory? File.expand_path('~/Library/Application Support/Pow/Hosts')


### PR DESCRIPTION
Bpwer is required to install ember-cli so this hotfix needs to be pushed.